### PR TITLE
Fix missing expansion icon

### DIFF
--- a/desktop/head_tag.html
+++ b/desktop/head_tag.html
@@ -3,6 +3,7 @@ src="https://cdnjs.cloudflare.com/ajax/libs/featherlight/1.7.13/featherlight.min
 ></script>
 
 <script type="text/discourse-plugin" version="0.8.18">
+const { iconHTML } = require("discourse-common/lib/icon-library");
 $.fn.dframes = function() {
   links = settings.iframe_origin_domains;
 
@@ -24,7 +25,7 @@ $.fn.dframes = function() {
       .before(
         "<button data-frame='#"+
           fId+
-          "' class='btn btn-default fExpand'><i class='fa fa-expand d-icon d-icon-expand'></i></button>"
+          "' class='btn btn-default fExpand'>" + iconHTML('discourse-expand') + "</i></button>"
       );
   });
 


### PR DESCRIPTION
@hnb-ku this will fix the expand icon for FA5. I have it make use of the `discourse-expand` icon.